### PR TITLE
fix: can't create user - 'Please correct invalid fields'

### DIFF
--- a/apps/cms/src/collections/Users.ts
+++ b/apps/cms/src/collections/Users.ts
@@ -1,6 +1,5 @@
 import type { CollectionConfig } from 'payload/types';
 import { authenticatedAndAdmin } from '../access/index';
-import { Select } from '../components/Select';
 
 export const usersSlug = 'users';
 const Users: CollectionConfig = {
@@ -26,11 +25,6 @@ const Users: CollectionConfig = {
             name: 'role',
             type: 'select',
             required: true,
-            admin: {
-                components: {
-                    Field: Select
-                }
-            },
             options: [
                 {
                     label: 'Admin',


### PR DESCRIPTION
After running this repo as per the instructions I couldn't create new users due to a form validation error. (see image below).

Looking at the Payload docs for the [select](https://payloadcms.com/docs/fields/select) field it looked like importing the Select component may not be necessary. Removing this fixed the validation issue.

This is my first Payload project so I don't know if I missed some deeper context for the Select component (I guess it was needed and worked a short while ago) but I thought it was worth suggesting this fix fix back into the project. 

<img width="885" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/63644/219979895-546742a2-dcd9-4dbb-aa4e-8309a7da9116.png">

ps. Thanks for creating this. It was exactly what I needed.
